### PR TITLE
Make credentials attribute optional

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,10 @@ terraform {
 
 provider "nango" {
   environment_key = "your-nango-environment-key"
+
+  # Optional: Set the base URL for self-hosted Nango instances.
+  # Defaults to https://api.nango.dev. Can also be set via the NANGO_HOST environment variable.
+  # host = "https://nango.example.com"
 }
 ```
 
@@ -33,3 +37,7 @@ provider "nango" {
 ### Required
 
 - `environment_key` (String)
+
+### Optional
+
+- `host` (String) The base URL for the Nango API. Defaults to `https://api.nango.dev`. Can also be set via the `NANGO_HOST` environment variable.

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -35,10 +35,13 @@ resource "nango_integration" "google" {
 
 ### Required
 
-- `credentials` (Attributes) The credentials for this integration (see [below for nested schema](#nestedatt--credentials))
 - `display_name` (String) The provider display name.
 - `nango_provider` (String) The nango_provider
 - `unique_key` (String) The integration ID that you created in Nango.
+
+### Optional
+
+- `credentials` (Attributes) The credentials for this integration (see [below for nested schema](#nestedatt--credentials))
 
 ### Read-Only
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -9,4 +9,8 @@ terraform {
 
 provider "nango" {
   environment_key = "your-nango-environment-key"
+
+  # Optional: Set the base URL for self-hosted Nango instances.
+  # Defaults to https://api.nango.dev. Can also be set via the NANGO_HOST environment variable.
+  # host = "https://nango.example.com"
 }

--- a/internal/provider/integration_data_source.go
+++ b/internal/provider/integration_data_source.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -21,7 +20,7 @@ var (
 )
 
 type integrationDataSource struct {
-	client *retryablehttp.Client
+	client *nangoClient
 }
 
 type nangoIntegrationResponse struct {
@@ -125,7 +124,7 @@ func (d *integrationDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 func (d *integrationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state integrationDataSourceModel
 
-	integrationsResponse, err := d.client.Get("https://api.nango.dev/integrations")
+	integrationsResponse, err := d.client.client.Get(d.client.baseURL + "/integrations")
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Integrations",
@@ -172,11 +171,11 @@ func (d *integrationDataSource) Configure(_ context.Context, req datasource.Conf
 		return
 	}
 
-	client, ok := req.ProviderData.(*retryablehttp.Client)
+	client, ok := req.ProviderData.(*nangoClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *retryablehttp.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *nangoClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return


### PR DESCRIPTION
As per the [api docs](https://nango.dev/docs/reference/api/integration/create), `credentials` is not required (e.g. to be able to create API_KEY type integrations)