### PR TITLE
fix: read back credentials.client_id in nango_integration Read() (CON-6127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
 ## 0.1.0 (Unreleased)
 
+BUG FIXES:
+
+* `nango_integration`: `Read()` now refreshes `credentials.client_id` from the
+  Nango API, so plans surface credential drift between Terraform and Nango.
+  Previously state always echoed the last-applied value, and because updates
+  send the full credentials object, any in-place change silently rewrote a
+  hand-corrected credential from a stale variable (CON-6127). Environments
+  where the dashboard value diverges from the Terraform variable will show a
+  one-time `~ client_id` diff — fix the variable/secret rather than applying
+  blindly.
+
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 BUG FIXES:
 
-* `nango_integration`: `Read()` now refreshes `credentials.client_id` from the
-  Nango API, so plans surface credential drift between Terraform and Nango.
-  Previously state always echoed the last-applied value, and because updates
-  send the full credentials object, any in-place change silently rewrote a
-  hand-corrected credential from a stale variable (CON-6127). Environments
-  where the dashboard value diverges from the Terraform variable will show a
-  one-time `~ client_id` diff — fix the variable/secret rather than applying
-  blindly.
+* `nango_integration`: `Read()` now refreshes `credentials.client_id` and
+  `credentials.client_secret` from the Nango API, so plans surface credential
+  drift between Terraform and Nango. Previously state always echoed the
+  last-applied values, and because updates send the full credentials object,
+  any in-place change silently rewrote a hand-corrected credential from a
+  stale variable (CON-6127). Environments where the dashboard values diverge
+  from the Terraform variables will show a one-time credentials diff — fix the
+  variable/secret rather than applying blindly.
+* `nango_integration`: `credentials.client_secret` is now marked sensitive, so
+  drift diffs render as `(sensitive value)` instead of printing the secret in
+  plan output. `client_id` intentionally stays visible — it is public in every
+  OAuth authorize URL, and seeing the actual value in a drift diff is what
+  makes credential incidents diagnosable.
 
 FEATURES:

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -50,7 +50,7 @@ resource "nango_integration" "google" {
 Required:
 
 - `client_id` (String) The client ID
-- `client_secret` (String) The client secret
+- `client_secret` (String, Sensitive) The client secret
 - `type` (String) The type of credential
 
 Optional:

--- a/internal/provider/integration_data_source.go
+++ b/internal/provider/integration_data_source.go
@@ -33,8 +33,9 @@ type nanogoIntegrationResponse2 struct {
 }
 
 type nangoCredentialsResponseModel struct {
-	Type   string `json:"type"`
-	Scopes string `json:"scopes"`
+	Type     string `json:"type"`
+	Scopes   string `json:"scopes"`
+	ClientId string `json:"client_id"`
 }
 
 type nangoIntegrationModel struct {

--- a/internal/provider/integration_data_source.go
+++ b/internal/provider/integration_data_source.go
@@ -33,9 +33,10 @@ type nanogoIntegrationResponse2 struct {
 }
 
 type nangoCredentialsResponseModel struct {
-	Type     string `json:"type"`
-	Scopes   string `json:"scopes"`
-	ClientId string `json:"client_id"`
+	Type         string `json:"type"`
+	Scopes       string `json:"scopes"`
+	ClientId     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
 }
 
 type nangoIntegrationModel struct {

--- a/internal/provider/integration_decode_test.go
+++ b/internal/provider/integration_decode_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestIntegrationResponseDecodesClientId pins the read-path contract that
+// credential drift detection depends on (CON-6127): the client_id returned by
+// GET /integrations/{key}?include=credentials must survive deserialization.
+// Before this field existed, Read() could never refresh client_id into state,
+// so a divergence between Nango and Terraform was invisible in plans.
+func TestIntegrationResponseDecodesClientId(t *testing.T) {
+	body := `{"data":{"unique_key":"service-outlook","display_name":"Outlook","provider":"outlook",` +
+		`"updated_at":"2026-07-29T00:00:00Z","credentials":{"type":"OAUTH2",` +
+		`"client_id":"ae7862fc-486d-43a3-9fc8-bfe2ba1e10f2","client_secret":"s","scopes":"a,b"}}}`
+
+	var resp nanogoIntegrationResponse2
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Data.Credentials == nil {
+		t.Fatal("credentials not decoded")
+	}
+	if got, want := resp.Data.Credentials.ClientId, "ae7862fc-486d-43a3-9fc8-bfe2ba1e10f2"; got != want {
+		t.Fatalf("client_id = %q, want %q", got, want)
+	}
+	if got, want := resp.Data.Credentials.Scopes, "a,b"; got != want {
+		t.Fatalf("scopes = %q, want %q", got, want)
+	}
+}

--- a/internal/provider/integration_decode_test.go
+++ b/internal/provider/integration_decode_test.go
@@ -28,6 +28,9 @@ func TestIntegrationResponseDecodesClientId(t *testing.T) {
 	if got, want := resp.Data.Credentials.ClientId, "ae7862fc-486d-43a3-9fc8-bfe2ba1e10f2"; got != want {
 		t.Fatalf("client_id = %q, want %q", got, want)
 	}
+	if got, want := resp.Data.Credentials.ClientSecret, "s"; got != want {
+		t.Fatalf("client_secret = %q, want %q", got, want)
+	}
 	if got, want := resp.Data.Credentials.Scopes, "a,b"; got != want {
 		t.Fatalf("scopes = %q, want %q", got, want)
 	}

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -215,6 +215,18 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.UpdatedAt = types.StringValue(integrationResp.Data.UpdatedAt)
 	}
 
+	// Refresh client_id from the API so Terraform can detect credential drift.
+	// Without this, state forever echoes the last-applied value and an
+	// out-of-band credential change (or a bad var about to be applied over a
+	// hand-corrected one) never shows in a plan — updates send the full
+	// credentials object, so the rewrite happens silently (CON-6127).
+	// client_secret is deliberately not refreshed yet: the endpoint does
+	// return it, but surfacing secret drift is a separate decision (CON-6127
+	// tracks it as a follow-up).
+	if integrationResp.Data.Credentials != nil && integrationResp.Data.Credentials.ClientId != "" && state.Credentials != nil {
+		state.Credentials.ClientId = types.StringValue(integrationResp.Data.Credentials.ClientId)
+	}
+
 	// Parse scopes from API response back into types.List so Terraform can detect drift
 	if integrationResp.Data.Credentials != nil && integrationResp.Data.Credentials.Scopes != "" {
 		scopeStrings := strings.Split(integrationResp.Data.Credentials.Scopes, ",")

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -83,6 +83,7 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 					},
 					"client_secret": schema.StringAttribute{
 						Required:            true,
+						Sensitive:           true,
 						MarkdownDescription: "The client secret",
 					},
 					"type": schema.StringAttribute{
@@ -215,16 +216,21 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.UpdatedAt = types.StringValue(integrationResp.Data.UpdatedAt)
 	}
 
-	// Refresh client_id from the API so Terraform can detect credential drift.
-	// Without this, state forever echoes the last-applied value and an
-	// out-of-band credential change (or a bad var about to be applied over a
-	// hand-corrected one) never shows in a plan — updates send the full
-	// credentials object, so the rewrite happens silently (CON-6127).
-	// client_secret is deliberately not refreshed yet: the endpoint does
-	// return it, but surfacing secret drift is a separate decision (CON-6127
-	// tracks it as a follow-up).
-	if integrationResp.Data.Credentials != nil && integrationResp.Data.Credentials.ClientId != "" && state.Credentials != nil {
-		state.Credentials.ClientId = types.StringValue(integrationResp.Data.Credentials.ClientId)
+	// Refresh client_id and client_secret from the API so Terraform can detect
+	// credential drift. Without this, state forever echoes the last-applied
+	// values and an out-of-band credential change (or a bad var about to be
+	// applied over a hand-corrected one) never shows in a plan — updates send
+	// the full credentials object, so the rewrite happens silently (CON-6127).
+	// The non-empty guards keep an API contract change (field dropped or
+	// masked to empty) from wiping state; a masked-to-placeholder change would
+	// surface as a loud perpetual diff rather than a silent clobber.
+	if integrationResp.Data.Credentials != nil && state.Credentials != nil {
+		if integrationResp.Data.Credentials.ClientId != "" {
+			state.Credentials.ClientId = types.StringValue(integrationResp.Data.Credentials.ClientId)
+		}
+		if integrationResp.Data.Credentials.ClientSecret != "" {
+			state.Credentials.ClientSecret = types.StringValue(integrationResp.Data.Credentials.ClientSecret)
+		}
 	}
 
 	// Parse scopes from API response back into types.List so Terraform can detect drift


### PR DESCRIPTION
Fixes the credential-drift blind spot that broke Microsoft OAuth in a developer Nango environment on 2026-07-28 (full RCA: [CON-6127](https://linear.app/contio/issue/CON-6127), incident thread: CON-6106).

## Problem

`Read()` fetches `GET /integrations/{key}?include=credentials` but copies only `updated_at` and `scopes` into state — `client_id` was not even deserialized (`nangoCredentialsResponseModel` lacked the field). State therefore always echoed the last-applied variable, so:

- divergence between Nango and Terraform never appeared in a plan, and
- because `Update()` sends the **full credentials object**, any in-place change to any attribute silently rewrote a hand-corrected credential from a stale variable. That is exactly how a `scopes -> null` cleanup replaced a working Microsoft `client_id` with a truncated one.

## Change

- `nangoCredentialsResponseModel`: deserialize `client_id` and `client_secret`.
- `Read()`: refresh `state.Credentials.ClientId` and `.ClientSecret` from the API response (non-empty guards so an API contract change surfaces as a loud diff, never a state wipe).
- Schema: `client_secret` is now `Sensitive` — secret drift renders as `(sensitive value)` instead of printing the secret into plan/CI logs. `client_id` intentionally stays visible: it is public in every OAuth authorize URL, and seeing the actual value in a drift diff is what made the incident diagnosable.
- Decode regression test (`integration_decode_test.go`).

## UAT — A/B against a live Nango environment

Local-state reproduction of the incident geometry (config == state == truncated id; Nango holds the correct id), `terraform plan` only, no applies:

| | v0.0.9 (released) | this branch (dev_overrides) |
|---|---|---|
| plan output | **"No changes."** | `~ client_id = "…e10f2" -> "…e10f"` |
| state after refresh | keeps stale value | holds Nango's real value |

The patched plan renders the exact would-be downgrade that the 07-28 apply performed silently.

Secret-drift UAT (second commit; sentinel secret in config+state, real secret only in Nango, zero secret material on disk): plan shows `~ client_secret = (sensitive value)` — drift detected, and the masking provably comes from the provider schema since the harness variables are non-sensitive.

## Rollout notes

- Environments where the dashboard credential was ever hand-fixed will show a **one-time `~ client_id` diff**. The correct response is fixing the variable/secret — never applying blindly, which reproduces the incident.
- After release: bump the pin in rome `terraform/modules/nango/main.tf` (currently `0.0.9`). Rome-side plan-time shape validations (rome PR #6221) complement this: they catch *malformed* values for Microsoft/Google; this catches *divergence* for all providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
